### PR TITLE
Modify twine check to be conditional

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Run tests
 on:
   push:
-    branches: [ master ]
+    branches: [ twine-cond ]
   pull_request:
     branches: [ master ]
 jobs:
@@ -51,8 +51,31 @@ jobs:
             pip install tox tox-gh-actions
         - name: Run integration tests
           run: tox -eintegration
+    changedfiles:
+      runs-on: ubuntu-latest
+      outputs:
+        # all files and rst files changed
+        all: ${{ steps.changes.outputs.all }}
+        rst: ${{ steps.changes.outputs.rst }}
+      steps:
+        - name: Checkout repository
+          uses: actions/checkout@v2
+          with:
+            # necessary to work with amended commits
+            fetch-depth: 2
+        - name: Get changed files
+          id: changes
+          run: |
+            echo "::set-output name=rst::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }} | grep .rst$ )"
+            echo "::set-output name=all::$(git diff-tree --no-commit-id --name-only -r ${{ github.sha }})"
+            echo "$all"
+            echo "$rst"
     twine:
       runs-on: ubuntu-latest
+      # requires previous job to run first
+      needs: changedfiles
+      # if only there are changed .rst files
+      if: ${{ needs.changedfiles.outputs.rst }}
       steps:
         - uses: actions/checkout@v2
         - name: Setup Python
@@ -64,4 +87,5 @@ jobs:
             python -m pip install --upgrade pip
             pip install tox tox-gh-actions
         - name: Run twine-check
-          run: tox -etwine
+          run: |
+            tox -etwine

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -5,8 +5,8 @@ pull_request_rules:
             rebase_fallback: merge
             strict: true
       conditions:
-          - label!=no-mergify
-          - '#approved-reviews-by>=1'
+          - label!=(no-mergify|WIP)
+          - '#approved-reviews-by>=2'
           - check-success=flake8
           - check-success=integration
           - check-success=test (2.7)

--- a/git_wrapper/tag.py
+++ b/git_wrapper/tag.py
@@ -72,3 +72,14 @@ class GitTag(object):
                 self.git_repo.git.push(remote, name)
         except git.GitCommandError as ex:
             raise_from(exceptions.PushException(msg), ex)
+
+    def names(self):
+        """List git tags in the repository."""
+        try:
+            tags_list = [x.name for x in self.git_repo.repo.tags]
+        except git.GitCommandError as ex:
+            repo_path = self.git_repo.repo.working_dir
+            msg = "Error listing tags for {repo}. Error: {error}".format(error=ex, repo=repo_path)
+            raise_from(exceptions.TaggingException(msg), ex)
+
+        return tags_list

--- a/integration_tests/test_tag.py
+++ b/integration_tests/test_tag.py
@@ -11,6 +11,9 @@ def test_tag(repo_root):
     repo.git.checkout("master")
     head = repo.repo.head.object.hexsha
 
+    # Test tag listing function names() by checking for tag name in test repo
+    assert '0.2.4' in repo.tag.names()
+
     # Test tag creation by tagging the current head
     repo.tag.create("test_tag", head)
 


### PR DESCRIPTION
Runs twine check only if .rst files have changed.
Adds an additional gh action "changedfiles" that
determines if .rst files have changed.
If "changedfiles" is true, twine check runs.

[Testing branch protection rules:
master branch required twine job status check to merge.]